### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,4 +676,4 @@ Models in MOSS-Audio are licensed under the Apache License 2.0.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=OpenMOSS/MOSS-Audio&type=date&legend=top-left)](https://www.star-history.com/#OpenMOSS/MOSS-Audio&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=OpenMOSS/MOSS-Audio&type=date&legend=top-left)](https://star-history.dera.page/#OpenMOSS/MOSS-Audio&type=date&legend=top-left)

--- a/README_zh.md
+++ b/README_zh.md
@@ -679,4 +679,4 @@ MOSS-Audio 中的模型基于 Apache License 2.0 许可证发布。
 
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=OpenMOSS/MOSS-Audio&type=date&legend=top-left)](https://www.star-history.com/#OpenMOSS/MOSS-Audio&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=OpenMOSS/MOSS-Audio&type=date&legend=top-left)](https://star-history.dera.page/#OpenMOSS/MOSS-Audio&type=date&legend=top-left)


### PR DESCRIPTION
The star history chart in the README is currently broken. This change updates the chart links in README.md and README_zh.md so they render correctly again.